### PR TITLE
uri.path instead of url

### DIFF
--- a/lib/faye/authentication/http_client.rb
+++ b/lib/faye/authentication/http_client.rb
@@ -6,7 +6,7 @@ module Faye
 
       def self.publish(url, channel, data, key)
         uri = URI(url)
-        req = Net::HTTP::Post.new(uri.path)
+        req = Net::HTTP::Post.new(uri.request_uri)
         message = {'channel' => channel, 'clientId' => 'http'}
         message['signature'] = Faye::Authentication.sign(message, key)
         message['data'] = data

--- a/lib/faye/authentication/http_client.rb
+++ b/lib/faye/authentication/http_client.rb
@@ -6,8 +6,8 @@ module Faye
 
       def self.publish(url, channel, data, key)
         uri = URI(url)
-        req = Net::HTTP::Post.new(url)
-        message = {'channel' => channel, 'clientId' => 'http'} 
+        req = Net::HTTP::Post.new(uri.path)
+        message = {'channel' => channel, 'clientId' => 'http'}
         message['signature'] = Faye::Authentication.sign(message, key)
         message['data'] = data
         req.set_form_data(message: JSON.dump(message))


### PR DESCRIPTION
I have Ruby Faye server

```ruby
Faye::RackAdapter.new(:mount => '/faye', :timeout => 25)
```

When I try to use 
```ruby
Faye::Authentication::HTTPClient.publish('http://localhost:9290/faye', '/channel', 'data', 'your private key')
```
I always have 404 response from the server