### PR TITLE
better: extract request building from publish method

### DIFF
--- a/lib/faye/authentication/http_client.rb
+++ b/lib/faye/authentication/http_client.rb
@@ -6,12 +6,17 @@ module Faye
 
       def self.publish(url, channel, data, key)
         uri = URI(url)
-        req = Net::HTTP::Post.new(uri.request_uri)
+        req = prepare_request(uri.request_uri, channel, data, key)
+        Net::HTTP.start(uri.hostname, uri.port, :use_ssl => uri.scheme == 'https') { |http| http.request(req) }
+      end
+
+      def self.prepare_request(uri, channel, data, key)
+        req = Net::HTTP::Post.new(uri)
         message = {'channel' => channel, 'clientId' => 'http'}
         message['signature'] = Faye::Authentication.sign(message, key)
         message['data'] = data
         req.set_form_data(message: JSON.dump(message))
-        Net::HTTP.start(uri.hostname, uri.port, :use_ssl => uri.scheme == 'https') { |http| http.request(req) }
+        req
       end
 
     end


### PR DESCRIPTION
This way, it can be reused when trying to use a connection pool to connect to faye